### PR TITLE
Update backend/README.md for clarity on windows operating systems

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@
 
 ```
 pip install -r requirements.txt
-uvicorn backend.app.main:app --reload
+python -m uvicorn backend.app.main:app --reload
 ```
 
 Open http://127.0.0.1:8000


### PR DESCRIPTION
making it a bit more clear for windows users where uvicorn doesn't automatically get added to path, Closes #23 