### PR TITLE
Add backend database connection and ORM models

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,30 @@
+import os
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+load_dotenv()
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://fdis_user:fdis_password@localhost:5432/fdis",
+)
+
+engine = create_engine(DATABASE_URL)
+
+SessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=engine,
+)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,14 @@
 import io
 from pathlib import Path
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import Depends, FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 import pandas as pd
 import joblib
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from backend.app.database import get_db
 
 app = FastAPI()
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -86,6 +89,12 @@ prediction_service = PredictionService(model_loader)
 @app.get("/")
 async def serve_frontend():
     return FileResponse(PROJECT_ROOT / "frontend" / "index.html")
+
+
+@app.get("/db/health")
+def database_health(db: Session = Depends(get_db)):
+    db.execute(text("SELECT 1"))
+    return {"database": "connected"}
 
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from backend.app.database import Base
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False, index=True)
+    description = Column(String(255), nullable=True)
+
+    users = relationship("User", back_populates="role")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    full_name = Column(String(255), nullable=True)
+
+    role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
+
+    is_active = Column(Boolean, default=True, nullable=False)
+    is_email_verified = Column(Boolean, default=False, nullable=False)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    role = relationship("Role", back_populates="users")
+    transactions = relationship("Transaction", back_populates="user")
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    step = Column(Integer, default=1, nullable=False)
+    type = Column(String(50), nullable=False)
+
+    amount = Column(Float, nullable=False)
+
+    # These column names are mapped to the actual lowercase PostgreSQL column names.
+    oldbalanceOrg = Column("oldbalanceorg", Float, nullable=False)
+    newbalanceOrig = Column("newbalanceorig", Float, nullable=False)
+    oldbalanceDest = Column("oldbalancedest", Float, nullable=False)
+    newbalanceDest = Column("newbalancedest", Float, nullable=False)
+
+    source = Column(String(20), default="single", nullable=False)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship("User", back_populates="transactions")
+    prediction_result = relationship(
+        "PredictionResult",
+        back_populates="transaction",
+        uselist=False,
+    )
+
+
+class PredictionResult(Base):
+    __tablename__ = "prediction_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    transaction_id = Column(Integer, ForeignKey("transactions.id"), nullable=False)
+
+    prediction = Column(Integer, nullable=False)
+    label = Column(String(50), nullable=False)
+    probability = Column(Float, nullable=False)
+
+    model_name = Column(String(100), nullable=True)
+    model_version = Column(String(100), nullable=True)
+    threshold = Column(Float, nullable=True)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    transaction = relationship("Transaction", back_populates="prediction_result")
+
+
+class EmailVerificationToken(Base):
+    __tablename__ = "email_verification_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    token = Column(String(255), unique=True, nullable=False, index=True)
+    expires_at = Column(DateTime, nullable=False)
+    used_at = Column(DateTime, nullable=True)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship("User")


### PR DESCRIPTION
## Summary

This PR adds the initial backend database integration for PostgreSQL.

## Changes

- Added SQLAlchemy database connection setup
- Added environment-based database configuration using `DATABASE_URL`
- Added SQLAlchemy ORM models for the existing database schema
- Added a `/db/health` endpoint to verify backend/database connectivity

## Models Added

The ORM layer now includes models for:

- `Role`
- `User`
- `Transaction`
- `PredictionResult`
- `EmailVerificationToken`

## Notes

This PR does not store users, transactions, or prediction results in the database yet.

The goal of this PR is only to connect the backend to the prepared PostgreSQL database and define ORM models for future persistence work.

## Validation

The local PostgreSQL container was started with Docker Compose.

The backend was started successfully with:

```bash
python3 -m uvicorn backend.app.main:app --reload
```

Close #39 